### PR TITLE
Use parent image from fedora registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM registry.redhat.io/rhel8/go-toolset:latest AS builder
+FROM registry.fedoraproject.org/fedora:34 AS builder
+
+RUN dnf -y install \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    golang
+
+WORKDIR /go/src/app
 COPY . .
-RUN go build -o /opt/app-root/src/bin/festoji main.go
+RUN go build -o bin/festoji main.go
+
 FROM scratch
-COPY --from=builder /opt/app-root/src/bin/festoji /usr/bin/festoji
+COPY --from=builder /go/src/app/bin/festoji /usr/bin/festoji
 CMD ["festoji"]


### PR DESCRIPTION
Ideally, we could just use the image from registry.redhat.io/rhel8/go-toolset:latest
But, the registry requires authentication and there doesn't seem to be
away to provide credentials for the builds done in quay.io.

The next best thing is to use the golang image from docker hub, docker.io/golang:1.16
You guessed it, that also requires authentication to avoid rate
limiting.

The third option is to use a Fedora base image and install golang on it.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>