### PR TITLE
Use public ubi pullspec for this base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
 WORKDIR /opt/app-root/src
 COPY . .
 RUN go build -o bin/festoji main.go


### PR DESCRIPTION
So that it is easily re-buildable.